### PR TITLE
Issue #1 fix for array parameters

### DIFF
--- a/pypd/mixins.py
+++ b/pypd/mixins.py
@@ -99,7 +99,7 @@ class ClientMixin(object):
             query_params.pop(k)
             values = [v_['id'] if isinstance(v_, ClientMixin) else v_
                       for v_ in v]
-            query_params[key] = ','.join(values)
+            query_params[key] = values
 
         kwargs = {
             'headers': headers,


### PR DESCRIPTION
PagerDuty API likes param[]=value1&param[]value2 not param[]=value1,value2 natation
Python requests library supports list values in such way