### PR TITLE
Fix Integration fetches

### DIFF
--- a/pypd/models/entity.py
+++ b/pypd/models/entity.py
@@ -260,7 +260,7 @@ class Entity(ClientMixin):
             endpoint = cls.get_endpoint()
 
         inst = cls(api_key=api_key)
-        parse_key = cls.sanitize_ep(endpoint)
+        parse_key = cls.sanitize_ep(endpoint).split("/")[-1]
         endpoint = '/'.join((endpoint, id))
         data = cls._parse(inst.request('GET',
                                        endpoint=endpoint,

--- a/pypd/models/integration.py
+++ b/pypd/models/integration.py
@@ -43,7 +43,7 @@ class Integration(Entity):
 
         if endpoint is None:
             sid = service['id'] if isinstance(service, Entity) else service
-            endpoint = '/incidents/{0}/integrations/{1}'.format(sid, id)
+            endpoint = '/services/{0}/integrations/{1}'.format(sid, id)
 
         getattr(Entity, 'fetch').im_func(cls, endpoint=endpoint, *args,
                                          **kwargs)

--- a/pypd/models/integration.py
+++ b/pypd/models/integration.py
@@ -43,9 +43,9 @@ class Integration(Entity):
 
         if endpoint is None:
             sid = service['id'] if isinstance(service, Entity) else service
-            endpoint = '/services/{0}/integrations/{1}'.format(sid, id)
+            endpoint = '/services/{0}/integrations'.format(sid)
 
-        getattr(Entity, 'fetch').im_func(cls, endpoint=endpoint, *args,
+        getattr(Entity, 'fetch').im_func(cls, id, endpoint=endpoint, *args,
                                          **kwargs)
 
     @classmethod

--- a/pypd/models/integration.py
+++ b/pypd/models/integration.py
@@ -45,8 +45,8 @@ class Integration(Entity):
             sid = service['id'] if isinstance(service, Entity) else service
             endpoint = '/services/{0}/integrations'.format(sid)
 
-        getattr(Entity, 'fetch').im_func(cls, id, endpoint=endpoint, *args,
-                                         **kwargs)
+        return getattr(Entity, 'fetch').im_func(cls, id, endpoint=endpoint,
+                                                *args, **kwargs)
 
     @classmethod
     def delete(*args, **kwargs):

--- a/pypd/models/service.py
+++ b/pypd/models/service.py
@@ -53,11 +53,11 @@ class Service(Entity):
     def integrations(self, **kwargs):
         """Retrieve all this services integrations."""
         ids = [ref['id'] for ref in self['integrations']]
-        return [Integration.fetch(id, query_params=kwargs) for id in ids]
+        return [Integration.fetch(id, service=self, query_params=kwargs) for id in ids]
 
     def get_integration(self, id, **kwargs):
         """Retrieve a single integration by id."""
-        return Integration.fetch(id, query_params=kwargs)
+        return Integration.fetch(id, service=self, query_params=kwargs)
 
     def update_integration(self, *args, **kwargs):
         """Update this integration on this service."""


### PR DESCRIPTION
`Integration` fetches appear to be completely broken at the moment.  This patchset represents the minimal diff I needed to successfully query a service for a list of attached integrations.