### PR TITLE
Add support for alerts and corresponding new features

### DIFF
--- a/pypd/__init__.py
+++ b/pypd/__init__.py
@@ -8,6 +8,7 @@ from .models.ability import can, abilities
 from .models.add_ons import AddOn
 from .models.escalation_policy import EscalationPolicy
 from .models.event import Event
+from .models.alert import Alert
 from .models.incident import Incident
 from .models.integration import Integration
 from .models.log_entry import LogEntry

--- a/pypd/models/alert.py
+++ b/pypd/models/alert.py
@@ -1,0 +1,73 @@
+# Copyright (c) PagerDuty.
+# See LICENSE for details.
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+from .entity import Entity
+
+
+class Alert(Entity):
+    def resolve(self, incident=None, from_email=None):
+        """Resolve an alert using a valid email address."""
+        if from_email is None:
+            raise Exception('%s.resolve requires \'from_email\' argument.')
+
+        if incident is None and endpoint is None:
+            raise InvalidArguments(incident, endpoint)
+
+        iid = incident['id'] if isinstance(incident, Entity) else incident
+        endpoint = 'incidents/{0}/alerts/{1}'.format(iid, self['id'])
+
+        add_headers = {'from': from_email, }
+        data = {
+            'alert': {
+                'id': iid,
+                'type': 'alert',
+                'status': 'resolved',
+            }
+        }
+
+        result = self.request('PUT',
+                              endpoint=endpoint,
+                              add_headers=add_headers,
+                              data=data,)
+        return result
+
+    def associate(self, incident=None, new_parent=None, from_email=None,):
+        """Associate an alert with an incident using a valid email address."""
+        if from_email is None:
+            raise Exception('%s.associate requires \'from_email\' argument.')
+
+        if new_parent is None:
+            raise Exception('%s.associate requires \'new_parent\' argument.')
+
+        iid = incident['id'] if isinstance(incident, Entity) else incident
+        endpoint = 'incidents/{0}/alerts/{1}'.format(iid, self['id'])
+
+        new_parent_id = new_parent['id'] if isinstance(new_parent, Entity) else new_parent
+
+        add_headers = {'from': from_email, }
+        data = {
+            'alert': {
+                'id': iid,
+                'type': 'alert',
+                'incident': {
+                    'type': 'incident',
+                    'id': new_parent_id,
+                }
+            }
+        }
+
+        print data
+
+        result = self.request('PUT',
+                              endpoint=endpoint,
+                              add_headers=add_headers,
+                              data=data,)
+        return result
+
+    def update(self, *args, **kwargs):
+        """Update an alert."""
+        raise NotImplemented

--- a/pypd/models/alert.py
+++ b/pypd/models/alert.py
@@ -10,6 +10,19 @@ from ..errors import InvalidArguments
 
 
 class Alert(Entity):
+    @classmethod
+    def fetch(cls, id, incident=None, endpoint=None, *args, **kwargs):
+        """Customize fetch because this is a nested resource."""
+        if incident is None and endpoint is None:
+            raise InvalidArguments(incident, endpoint)
+
+        if endpoint is None:
+            iid = incident['id'] if isinstance(incident, Entity) else incident
+            endpoint = 'incidents/{0}/alerts'.format(iid)
+
+        return getattr(Entity, 'fetch').__func__(cls, id, endpoint=endpoint,
+                                                 *args, **kwargs)
+
     def resolve(self, from_email=None):
         """Resolve an alert using a valid email address."""
         if from_email is None:

--- a/pypd/models/alert.py
+++ b/pypd/models/alert.py
@@ -29,7 +29,8 @@ class Alert(Entity):
             raise InvalidArguments(from_email)
 
         parent_incident_id = self['incident']['id']
-        endpoint = 'incidents/{0}/alerts/{1}'.format(parent_incident_id, self['id'])
+        endpoint_format = 'incidents/{0}/alerts/{1}'
+        endpoint = endpoint_format.format(parent_incident_id, self['id'])
 
         add_headers = {'from': from_email, }
         data = {
@@ -55,7 +56,8 @@ class Alert(Entity):
             raise InvalidArguments(new_parent_incident)
 
         parent_incident_id = self['incident']['id']
-        endpoint = 'incidents/{0}/alerts/{1}'.format(parent_incident_id, self['id'])
+        endpoint_format = 'incidents/{0}/alerts/{1}'
+        endpoint = endpoint_format.format(parent_incident_id, self['id'])
 
         if isinstance(new_parent_incident, Entity):
             new_parent_incident_id = new_parent_incident['id']

--- a/pypd/models/alert.py
+++ b/pypd/models/alert.py
@@ -44,7 +44,10 @@ class Alert(Entity):
         parent_incident_id = self['incident']['id']
         endpoint = 'incidents/{0}/alerts/{1}'.format(parent_incident_id, self['id'])
 
-        new_parent_incident_id = new_parent_incident['id'] if isinstance(new_parent_incident, Entity) else new_parent_incident
+        if isinstance(new_parent_incident, Entity):
+            new_parent_incident_id = new_parent_incident['id']
+        else:
+            new_parent_incident_id = new_parent_incident
 
         add_headers = {'from': from_email, }
         data = {

--- a/pypd/models/alert.py
+++ b/pypd/models/alert.py
@@ -6,13 +6,14 @@ except ImportError:
     import json
 
 from .entity import Entity
+from ..errors import InvalidArguments
 
 
 class Alert(Entity):
     def resolve(self, from_email=None):
         """Resolve an alert using a valid email address."""
         if from_email is None:
-            raise Exception('%s.resolve requires \'from_email\' argument.')
+            raise InvalidArguments(from_email)
 
         parent_incident_id = self['incident']['id']
         endpoint = 'incidents/{0}/alerts/{1}'.format(parent_incident_id, self['id'])
@@ -35,10 +36,10 @@ class Alert(Entity):
     def associate(self, new_parent_incident=None, from_email=None,):
         """Associate an alert with an incident using a valid email address."""
         if from_email is None:
-            raise Exception('%s.associate requires \'from_email\' argument.')
+            raise InvalidArguments(from_email)
 
         if new_parent_incident is None:
-            raise Exception('%s.associate requires \'new_parent_incident\' argument.')
+            raise InvalidArguments(new_parent_incident)
 
         parent_incident_id = self['incident']['id']
         endpoint = 'incidents/{0}/alerts/{1}'.format(parent_incident_id, self['id'])

--- a/pypd/models/alert.py
+++ b/pypd/models/alert.py
@@ -9,21 +9,18 @@ from .entity import Entity
 
 
 class Alert(Entity):
-    def resolve(self, incident=None, from_email=None):
+    def resolve(self, from_email=None):
         """Resolve an alert using a valid email address."""
         if from_email is None:
             raise Exception('%s.resolve requires \'from_email\' argument.')
 
-        if incident is None and endpoint is None:
-            raise InvalidArguments(incident, endpoint)
-
-        iid = incident['id'] if isinstance(incident, Entity) else incident
-        endpoint = 'incidents/{0}/alerts/{1}'.format(iid, self['id'])
+        parent_incident_id = self['incident']['id']
+        endpoint = 'incidents/{0}/alerts/{1}'.format(parent_incident_id, self['id'])
 
         add_headers = {'from': from_email, }
         data = {
             'alert': {
-                'id': iid,
+                'id': self['id'],
                 'type': 'alert',
                 'status': 'resolved',
             }
@@ -35,32 +32,30 @@ class Alert(Entity):
                               data=data,)
         return result
 
-    def associate(self, incident=None, new_parent=None, from_email=None,):
+    def associate(self, new_parent_incident=None, from_email=None,):
         """Associate an alert with an incident using a valid email address."""
         if from_email is None:
             raise Exception('%s.associate requires \'from_email\' argument.')
 
-        if new_parent is None:
-            raise Exception('%s.associate requires \'new_parent\' argument.')
+        if new_parent_incident is None:
+            raise Exception('%s.associate requires \'new_parent_incident\' argument.')
 
-        iid = incident['id'] if isinstance(incident, Entity) else incident
-        endpoint = 'incidents/{0}/alerts/{1}'.format(iid, self['id'])
+        parent_incident_id = self['incident']['id']
+        endpoint = 'incidents/{0}/alerts/{1}'.format(parent_incident_id, self['id'])
 
-        new_parent_id = new_parent['id'] if isinstance(new_parent, Entity) else new_parent
+        new_parent_incident_id = new_parent_incident['id'] if isinstance(new_parent_incident, Entity) else new_parent_incident
 
         add_headers = {'from': from_email, }
         data = {
             'alert': {
-                'id': iid,
+                'id': self['id'],
                 'type': 'alert',
                 'incident': {
                     'type': 'incident',
-                    'id': new_parent_id,
+                    'id': new_parent_incident_id,
                 }
             }
         }
-
-        print data
 
         result = self.request('PUT',
                               endpoint=endpoint,

--- a/pypd/models/incident.py
+++ b/pypd/models/incident.py
@@ -126,12 +126,10 @@ class Incident(Entity):
         transform_incident_to_id = lambda x: x['id'] if isinstance(x, Entity) else x
         source_incidents_ids = list(map(transform_incident_to_id, source_incidents))
 
-        transform_incident_ids_to_api_object = lambda x: { 'type': 'incident_reference', 'id': x }
+        transform_incident_ids_to_api_object = lambda x: {'type': 'incident_reference', 'id': x, }
         source_incidents_object = list(map(transform_incident_ids_to_api_object, source_incidents_ids))
 
-        data = {
-            'source_incidents': source_incidents_object
-        }
+        data = {'source_incidents': source_incidents_object, }
 
         result = self.request('PUT',
                               endpoint=endpoint,

--- a/pypd/models/incident.py
+++ b/pypd/models/incident.py
@@ -9,6 +9,7 @@ from .entity import Entity
 from .log_entry import LogEntry
 from .note import Note
 from .alert import Alert
+from ..errors import InvalidArguments
 
 
 class Incident(Entity):
@@ -116,7 +117,7 @@ class Incident(Entity):
     def merge(self, source_incidents, from_email=None,):
         """Merge incidents into this incident."""
         if from_email is None:
-            raise Exception('%s.merge requires \'from_email\' argument.')
+            raise InvalidArguments(from_email)
 
         add_headers = {'from': from_email, }
 

--- a/pypd/models/incident.py
+++ b/pypd/models/incident.py
@@ -113,6 +113,31 @@ class Incident(Entity):
             data={'duration': duration},
         )
 
+    def merge(self, source_incidents, from_email=None,):
+        """Merge incidents into this incident."""
+        if from_email is None:
+            raise Exception('%s.merge requires \'from_email\' argument.')
+
+        add_headers = {'from': from_email, }
+
+        endpoint = '/'.join((self.endpoint, self.id, 'merge'))
+
+        transform_incident_to_id = lambda x: x['id'] if isinstance(x, Entity) else x
+        source_incidents_ids = list(map(transform_incident_to_id, source_incidents))
+
+        transform_incident_ids_to_api_object = lambda x: { 'type': 'incident_reference', 'id': x }
+        source_incidents_object = list(map(transform_incident_ids_to_api_object, source_incidents_ids))
+
+        data = {
+            'source_incidents': source_incidents_object
+        }
+
+        result = self.request('PUT',
+                              endpoint=endpoint,
+                              add_headers=add_headers,
+                              data=data,)
+        return result
+
     def alerts(self):
         """Query for alerts attached to this incident."""
         endpoint = '/'.join((self.endpoint, self.id, 'alerts'))

--- a/pypd/models/incident.py
+++ b/pypd/models/incident.py
@@ -8,11 +8,13 @@ except ImportError:
 from .entity import Entity
 from .log_entry import LogEntry
 from .note import Note
+from .alert import Alert
 
 
 class Incident(Entity):
     logEntryFactory = LogEntry
     noteFactory = Note
+    alertFactory = Alert
 
     def resolve(self, from_email=None, resolution=None,):
         """Resolve an incident using a valid email address."""
@@ -109,4 +111,12 @@ class Incident(Entity):
             endpoint=endpoint,
             api_key=self.api_key,
             data={'duration': duration},
+        )
+
+    def alerts(self):
+        """Query for alerts attached to this incident."""
+        endpoint = '/'.join((self.endpoint, self.id, 'alerts'))
+        return self.alertFactory.find(
+            endpoint=endpoint,
+            api_key=self.api_key,
         )

--- a/pypd/models/incident.py
+++ b/pypd/models/incident.py
@@ -114,6 +114,12 @@ class Incident(Entity):
             data={'duration': duration},
         )
 
+    def _extract_entity_id(incident):
+        return x['id'] if isinstance(x, Entity) else x
+
+    def _incident_to_object(incident_id):
+        return {'type': 'incident_reference', 'id': incident_id, }
+
     def merge(self, source_incidents, from_email=None,):
         """Merge incidents into this incident."""
         if from_email is None:
@@ -123,13 +129,11 @@ class Incident(Entity):
 
         endpoint = '/'.join((self.endpoint, self.id, 'merge'))
 
-        transform_incident_to_id = lambda x: x['id'] if isinstance(x, Entity) else x
-        source_incidents_ids = list(map(transform_incident_to_id, source_incidents))
+        source_ids = list(map(_extract_entity_id, source_incidents))
 
-        transform_incident_ids_to_api_object = lambda x: {'type': 'incident_reference', 'id': x, }
-        source_incidents_object = list(map(transform_incident_ids_to_api_object, source_incidents_ids))
+        source_object = list(map(_incident_to_object, source_ids))
 
-        data = {'source_incidents': source_incidents_object, }
+        data = {'source_incidents': source_object, }
 
         result = self.request('PUT',
                               endpoint=endpoint,

--- a/test/data/sample_alerts.json
+++ b/test/data/sample_alerts.json
@@ -1,0 +1,86 @@
+[
+    {
+        "alert_key": "second",
+        "created_at": "2017-04-06T23:41:08-04:00",
+        "first_trigger_log_entry":
+        {
+            "html_url": "https://fake.pagerduty.com/alerts/ALERT1/log_entries/ALOGENTRY1",
+            "id": "ALOGENTRY1",
+            "self": "https://api.pagerduty.com/log_entries/ALOGENTRY1",
+            "summary": "Triggered through the API",
+            "type": "trigger_log_entry_reference"
+        },
+        "html_url": "https://fake.pagerduty.com/alerts/ALERT1",
+        "id": "ALERT1",
+        "incident":
+        {
+            "html_url": "https://fake.pagerduty.com/incidents/INCIDENT1",
+            "id": "INCIDENT1",
+            "self": "https://api.pagerduty.com/incidents/INCIDENT1",
+            "summary": "[#1] this is a trigger event!",
+            "type": "incident_reference"
+        },
+        "integration":
+        {
+            "html_url": "https://fake.pagerduty.com/services/SERVICE1/integrations/INTEGRATION1",
+            "id": "SERVICE1",
+            "self": "https://api.pagerduty.com/services/SERVICE1/integrations/INTEGRATION1",
+            "summary": "API Alert",
+            "type": "generic_events_api_inbound_integration_reference"
+        },
+        "self": "https://api.pagerduty.com/alerts/ALERT1",
+        "service":
+        {
+            "html_url": "https://fake.pagerduty.com/services/SERVICE1",
+            "id": "SERVICE1",
+            "self": "https://api.pagerduty.com/services/SERVICE1",
+            "summary": "Alert and Incidents",
+            "type": "service_reference"
+        },
+        "status": "resolved",
+        "summary": "this is a trigger event!",
+        "type": "alert"
+    },
+    {
+        "alert_key": "second",
+        "created_at": "2017-04-06T23:41:07-04:00",
+        "first_trigger_log_entry":
+        {
+            "html_url": "https://fake.pagerduty.com/alerts/ALERT2/log_entries/ALOGENTRY2",
+            "id": "ALOGENTRY2",
+            "self": "https://api.pagerduty.com/log_entries/ALOGENTRY2",
+            "summary": "Triggered through the API",
+            "type": "trigger_log_entry_reference"
+        },
+        "html_url": "https://fake.pagerduty.com/alerts/ALERT2",
+        "id": "ALERT2",
+        "incident":
+        {
+            "html_url": "https://fake.pagerduty.com/incidents/INCIDENT1",
+            "id": "INCIDENT1",
+            "self": "https://api.pagerduty.com/incidents/INCIDENT1",
+            "summary": "[#1] this is a trigger event!",
+            "type": "incident_reference"
+        },
+        "integration":
+        {
+            "html_url": "https://fake.pagerduty.com/services/SERVICE1/integrations/INTEGRATION1",
+            "id": "INTEGRATION1",
+            "self": "https://api.pagerduty.com/services/SERVICE1/integrations/INTEGRATION1",
+            "summary": "API Alert",
+            "type": "generic_events_api_inbound_integration_reference"
+        },
+        "self": "https://api.pagerduty.com/alerts/ALERT2",
+        "service":
+        {
+            "html_url": "https://fake.pagerduty.com/services/SERVICE1",
+            "id": "SERVICE1",
+            "self": "https://api.pagerduty.com/services/SERVICE1",
+            "summary": "Alert and Incidents",
+            "type": "service_reference"
+        },
+        "status": "resolved",
+        "summary": "this is a trigger event!",
+        "type": "alert"
+    }
+]

--- a/test/data/sample_incidents.json
+++ b/test/data/sample_incidents.json
@@ -1,0 +1,138 @@
+[
+    {
+        "incident_number": 1,
+        "title": "this is a trigger event!",
+        "description": "this is a trigger event!",
+        "created_at": "2017-04-07T03:41:08Z",
+        "status": "resolved",
+        "pending_actions": [],
+        "incident_key": null,
+        "service":
+        {
+            "id": "SERVICE1",
+            "type": "service_reference",
+            "summary": "Alert and Incidents",
+            "self": "https://api.pagerduty.com/services/SERVICE1",
+            "html_url": "https://fake.pagerduty.com/services/SERVICE1"
+        },
+        "assignments": [],
+        "acknowledgements": [],
+        "last_status_change_at": "2017-04-07T03:57:56Z",
+        "last_status_change_by":
+        {
+            "id": "USER1",
+            "type": "user_reference",
+            "summary": "Nizar Gharbi",
+            "self": "https://api.pagerduty.com/users/USER1",
+            "html_url": "https://fake.pagerduty.com/users/USER1"
+        },
+        "first_trigger_log_entry":
+        {
+            "id": "LOGENTRY1",
+            "type": "trigger_log_entry_reference",
+            "summary": "Triggered through the API",
+            "self": "https://api.pagerduty.com/log_entries/LOGENTRY1",
+            "html_url": "https://fake.pagerduty.com/incidents/INCIDENT1/log_entries/LOGENTRY1"
+        },
+        "escalation_policy":
+        {
+            "id": "EP1",
+            "type": "escalation_policy_reference",
+            "summary": "Default",
+            "self": "https://api.pagerduty.com/escalation_policies/EP1",
+            "html_url": "https://fake.pagerduty.com/escalation_policies/EP1"
+        },
+        "alert_counts":
+        {
+            "all": 2,
+            "triggered": 0,
+            "resolved": 2
+        },
+        "impacted_services":
+        [
+            {
+                "id": "SERVICE1",
+                "type": "service_reference",
+                "summary": "Alert and Incidents",
+                "self": "https://api.pagerduty.com/services/SERVICE1",
+                "html_url": "https://fake.pagerduty.com/services/SERVICE1"
+            }
+        ],
+        "is_mergeable": true,
+        "resolve_reason": null,
+        "urgency": "high",
+        "id": "INCIDENT1",
+        "type": "incident",
+        "summary": "[#1] this is a trigger event!",
+        "self": "https://api.pagerduty.com/incidents/INCIDENT1",
+        "html_url": "https://fake.pagerduty.com/incidents/INCIDENT1"
+    },
+    {
+        "incident_number": 2,
+        "title": "this is another trigger event!",
+        "description": "this is another trigger event!",
+        "created_at": "2017-04-07T03:41:08Z",
+        "status": "resolved",
+        "pending_actions": [],
+        "incident_key": null,
+        "service":
+        {
+            "id": "SERVICE2",
+            "type": "service_reference",
+            "summary": "Alert and Incidents",
+            "self": "https://api.pagerduty.com/services/SERVICE2",
+            "html_url": "https://fake.pagerduty.com/services/SERVICE2"
+        },
+        "assignments": [],
+        "acknowledgements": [],
+        "last_status_change_at": "2017-04-07T03:57:56Z",
+        "last_status_change_by":
+        {
+            "id": "USER2",
+            "type": "user_reference",
+            "summary": "Nizar Not Gharbi",
+            "self": "https://api.pagerduty.com/users/USER2",
+            "html_url": "https://fake.pagerduty.com/users/USER2"
+        },
+        "first_trigger_log_entry":
+        {
+            "id": "LOGENTRY2",
+            "type": "trigger_log_entry_reference",
+            "summary": "Triggered through the API",
+            "self": "https://api.pagerduty.com/log_entries/LOGENTRY2",
+            "html_url": "https://fake.pagerduty.com/incidents/INCIDENT2/log_entries/LOGENTRY2"
+        },
+        "escalation_policy":
+        {
+            "id": "EP2",
+            "type": "escalation_policy_reference",
+            "summary": "Not very Default",
+            "self": "https://api.pagerduty.com/escalation_policies/EP2",
+            "html_url": "https://fake.pagerduty.com/escalation_policies/EP2"
+        },
+        "alert_counts":
+        {
+            "all": 0,
+            "triggered": 0,
+            "resolved": 0
+        },
+        "impacted_services":
+        [
+            {
+                "id": "SERVICE2",
+                "type": "service_reference",
+                "summary": "Alert and Incidents",
+                "self": "https://api.pagerduty.com/services/SERVICE2",
+                "html_url": "https://fake.pagerduty.com/services/SERVICE2"
+            }
+        ],
+        "is_mergeable": true,
+        "resolve_reason": null,
+        "urgency": "high",
+        "id": "INCIDENT2",
+        "type": "incident",
+        "summary": "[#2] this is another trigger event!",
+        "self": "https://api.pagerduty.com/incidents/INCIDENT2",
+        "html_url": "https://fake.pagerduty.com/incidents/INCIDENT2"
+    }
+]

--- a/test/unit/models/alert.py
+++ b/test/unit/models/alert.py
@@ -9,14 +9,17 @@ import requests_mock
 from pypd import Incident, Alert
 from pypd.errors import InvalidArguments
 
-def get_mock_object_by_id(data, search_id):
+
+def get_object_by_id(data, search_id):
     return list(filter(
         lambda s: s['id'] == search_id,
         data,
     ))[0]
 
-def get_mock_data(data_type, mock_object):
+
+def get_data(data_type, mock_object):
     return {data_type: mock_object}
+
 
 class AlertTestCase(unittest.TestCase):
 
@@ -36,20 +39,24 @@ class AlertTestCase(unittest.TestCase):
             self.alerts_data = json.load(f)
 
         self.first_incident_id = 'INCIDENT1'
-        self.first_incident = get_mock_object_by_id(self.incidents_data, self.first_incident_id)
-        self.first_incident_data = get_mock_data('incident', self.first_incident)
+        self.first_incident = get_object_by_id(
+            self.incidents_data, self.first_incident_id)
+        self.first_incident_data = get_data('incident', self.first_incident)
 
         self.second_incident_id = 'INCIDENT2'
-        self.second_incident = get_mock_object_by_id(self.incidents_data, self.second_incident_id)
-        self.second_incident_data = get_mock_data('incident', self.second_incident)
+        self.second_incident = get_object_by_id(
+            self.incidents_data, self.second_incident_id)
+        self.second_incident_data = get_data('incident', self.second_incident)
 
         self.first_alert_id = 'ALERT1'
-        self.first_alert = get_mock_object_by_id(self.alerts_data, self.first_alert_id)
-        self.first_alert_data = get_mock_data('alert', self.first_alert)
+        self.first_alert = get_object_by_id(
+            self.alerts_data, self.first_alert_id)
+        self.first_alert_data = get_data('alert', self.first_alert)
 
         self.second_alert_id = 'ALERT2'
-        self.second_alert = get_mock_object_by_id(self.alerts_data, self.second_alert_id)
-        self.second_alert_data = get_mock_data('alert', self.second_alert)
+        self.second_alert = get_object_by_id(
+            self.alerts_data, self.second_alert_id)
+        self.second_alert_data = get_data('alert', self.second_alert)
 
     # Test helpers
     def build_incident_url(self, incident_id):
@@ -92,7 +99,8 @@ class AlertTestCase(unittest.TestCase):
         self.mock_get_request(m, incident_url, self.first_incident_data)
 
         alerts_url = self.build_incident_alerts_url(self.first_incident_id)
-        self.mock_get_request(m, alerts_url, {'alerts': [self.first_alert, self.second_alert, ]})
+        self.mock_get_request(
+            m, alerts_url, {'alerts': [self.first_alert, self.second_alert, ]})
 
         incident = Incident.fetch(self.first_incident_id, api_key=self.api_key)
         alerts = incident.alerts()
@@ -106,15 +114,20 @@ class AlertTestCase(unittest.TestCase):
         incident_url = self.build_incident_url(self.first_incident_id)
         self.mock_get_request(m, incident_url, self.first_incident_data)
 
-        incident_alerts_url = self.build_incident_alerts_url(self.first_incident_id)
-        self.mock_get_request(m, incident_alerts_url, {'alerts': [self.first_alert, self.second_alert, ]})
+        incident_alerts_url = self.build_incident_alerts_url(
+            self.first_incident_id)
+        self.mock_get_request(
+            m, incident_alerts_url,
+            {'alerts': [self.first_alert, self.second_alert, ]})
 
-        alert_url = self.build_alert_url(self.first_incident_id, self.first_alert_id)
+        alert_url = self.build_alert_url(
+            self.first_incident_id, self.first_alert_id)
         self.mock_get_request(m, alert_url, self.first_alert_data)
 
         incident = Incident.fetch(self.first_incident_id, api_key=self.api_key)
         alerts = incident.alerts()
-        alert = Alert.fetch(self.first_alert_id, incident, None, api_key=self.api_key)
+        alert = Alert.fetch(
+            self.first_alert_id, incident, None, api_key=self.api_key)
 
         incident_alert_ids = [i.id for i in alerts]
         self.assertIn(alert.id, incident_alert_ids)
@@ -124,12 +137,14 @@ class AlertTestCase(unittest.TestCase):
         incident_url = self.build_incident_url(self.first_incident_id)
         self.mock_get_request(m, incident_url, self.first_incident_data)
 
-        alert_url = self.build_alert_url(self.first_incident_id, self.first_alert_id)
+        alert_url = self.build_alert_url(
+            self.first_incident_id, self.first_alert_id)
         self.mock_get_request(m, alert_url, self.first_alert_data)
         self.mock_put_request(m, alert_url, self.first_alert_data)
 
         incident = Incident.fetch(self.first_incident_id, api_key=self.api_key)
-        alert = Alert.fetch(self.first_alert_id, incident, None, api_key=self.api_key)
+        alert = Alert.fetch(
+            self.first_alert_id, incident, None, api_key=self.api_key)
         alert.resolve('nizar@pagerduty.com')
 
         last_request_json = m.last_request.json()
@@ -143,21 +158,27 @@ class AlertTestCase(unittest.TestCase):
         self.mock_get_request(m, incident_url, self.first_incident_data)
 
         second_incident_url = self.build_incident_url(self.second_incident_id)
-        self.mock_get_request(m, second_incident_url, self.second_incident_data)
+        self.mock_get_request(
+            m, second_incident_url, self.second_incident_data)
 
-        alert_url = self.build_alert_url(self.first_incident_id, self.first_alert_id)
+        alert_url = self.build_alert_url(
+            self.first_incident_id, self.first_alert_id)
         self.mock_get_request(m, alert_url, self.first_alert_data)
         self.mock_put_request(m, alert_url, self.first_alert_data)
 
         incident = Incident.fetch(self.first_incident_id, api_key=self.api_key)
-        new_incident = Incident.fetch(self.second_incident_id, api_key=self.api_key)
-        alert = Alert.fetch(self.first_alert_id, incident, None, api_key=self.api_key)
+        new_incident = Incident.fetch(
+            self.second_incident_id, api_key=self.api_key)
+        alert = Alert.fetch(
+            self.first_alert_id, incident, None, api_key=self.api_key)
         alert.associate(new_incident, 'nizar@pagerduty.com')
 
         last_request_json = m.last_request.json()
         self.assertEqual('PUT', m.last_request.method)
         self.assertEqual(self.first_alert_id, last_request_json['alert']['id'])
-        self.assertEqual(self.second_incident_id, last_request_json['alert']['incident']['id'])
+        self.assertEqual(
+            self.second_incident_id,
+            last_request_json['alert']['incident']['id'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/models/alert.py
+++ b/test/unit/models/alert.py
@@ -1,0 +1,163 @@
+# Copyright (c) PagerDuty.
+# See LICENSE for details.
+import json
+import unittest
+import os.path
+
+import requests_mock
+
+from pypd import Incident, Alert
+from pypd.errors import InvalidArguments
+
+def get_mock_object_by_id(data, search_id):
+    return list(filter(
+        lambda s: s['id'] == search_id,
+        data,
+    ))[0]
+
+def get_mock_data(data_type, mock_object):
+    return {data_type: mock_object}
+
+class AlertTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.base_url = 'https://api.pagerduty.com'
+        self.api_key = 'FAUX_API_KEY'
+        self.limit = 25
+        base_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            'data')
+        path = os.path.join(base_path, 'sample_incidents.json')
+        with open(path) as f:
+            self.incidents_data = json.load(f)
+
+        path = os.path.join(base_path, 'sample_alerts.json')
+        with open(path) as f:
+            self.alerts_data = json.load(f)
+
+        self.first_incident_id = 'INCIDENT1'
+        self.first_incident = get_mock_object_by_id(self.incidents_data, self.first_incident_id)
+        self.first_incident_data = get_mock_data('incident', self.first_incident)
+
+        self.second_incident_id = 'INCIDENT2'
+        self.second_incident = get_mock_object_by_id(self.incidents_data, self.second_incident_id)
+        self.second_incident_data = get_mock_data('incident', self.second_incident)
+
+        self.first_alert_id = 'ALERT1'
+        self.first_alert = get_mock_object_by_id(self.alerts_data, self.first_alert_id)
+        self.first_alert_data = get_mock_data('alert', self.first_alert)
+
+        self.second_alert_id = 'ALERT2'
+        self.second_alert = get_mock_object_by_id(self.alerts_data, self.second_alert_id)
+        self.second_alert_data = get_mock_data('alert', self.second_alert)
+
+    # Test helpers
+    def build_incident_url(self, incident_id):
+        return '{0}/incidents/{1}'.format(
+            self.base_url,
+            incident_id,
+        )
+
+    def build_incident_alerts_url(self, incident_id):
+        return '{0}/incidents/{1}/alerts'.format(
+            self.base_url,
+            incident_id,
+        )
+
+    def build_alert_url(self, incident_id, alert_id):
+        return '{0}/incidents/{1}/alerts/{2}'.format(
+            self.base_url,
+            incident_id,
+            alert_id,
+        )
+
+    def mock_request(self, m, method, url, payload):
+        m.register_uri(
+            method,
+            url,
+            json=payload,
+            complete_qs=False
+        )
+
+    def mock_get_request(self, m, url, payload):
+        self.mock_request(m, 'GET', url, payload)
+
+    def mock_put_request(self, m, url, payload):
+        self.mock_request(m, 'PUT', url, payload)
+
+    # Tests
+    @requests_mock.Mocker()
+    def test_fetch_all_alerts_from_incident(self, m):
+        incident_url = self.build_incident_url(self.first_incident_id)
+        self.mock_get_request(m, incident_url, self.first_incident_data)
+
+        alerts_url = self.build_incident_alerts_url(self.first_incident_id)
+        self.mock_get_request(m, alerts_url, {'alerts': [self.first_alert, self.second_alert, ]})
+
+        incident = Incident.fetch(self.first_incident_id, api_key=self.api_key)
+        alerts = incident.alerts()
+        alert_ids = [i.id for i in alerts]
+
+        for alert_id in [self.first_alert_id, self.second_alert_id]:
+            self.assertIn(alert_id, alert_ids)
+
+    @requests_mock.Mocker()
+    def test_fetch_one_from_incident(self, m):
+        incident_url = self.build_incident_url(self.first_incident_id)
+        self.mock_get_request(m, incident_url, self.first_incident_data)
+
+        incident_alerts_url = self.build_incident_alerts_url(self.first_incident_id)
+        self.mock_get_request(m, incident_alerts_url, {'alerts': [self.first_alert, self.second_alert, ]})
+
+        alert_url = self.build_alert_url(self.first_incident_id, self.first_alert_id)
+        self.mock_get_request(m, alert_url, self.first_alert_data)
+
+        incident = Incident.fetch(self.first_incident_id, api_key=self.api_key)
+        alerts = incident.alerts()
+        alert = Alert.fetch(self.first_alert_id, incident, None, api_key=self.api_key)
+
+        incident_alert_ids = [i.id for i in alerts]
+        self.assertIn(alert.id, incident_alert_ids)
+
+    @requests_mock.Mocker()
+    def test_resolve(self, m):
+        incident_url = self.build_incident_url(self.first_incident_id)
+        self.mock_get_request(m, incident_url, self.first_incident_data)
+
+        alert_url = self.build_alert_url(self.first_incident_id, self.first_alert_id)
+        self.mock_get_request(m, alert_url, self.first_alert_data)
+        self.mock_put_request(m, alert_url, self.first_alert_data)
+
+        incident = Incident.fetch(self.first_incident_id, api_key=self.api_key)
+        alert = Alert.fetch(self.first_alert_id, incident, None, api_key=self.api_key)
+        alert.resolve('nizar@pagerduty.com')
+
+        last_request_json = m.last_request.json()
+        self.assertEqual('PUT', m.last_request.method)
+        self.assertEqual(self.first_alert_id, last_request_json['alert']['id'])
+        self.assertEqual('resolved', last_request_json['alert']['status'])
+
+    @requests_mock.Mocker()
+    def test_associate(self, m):
+        incident_url = self.build_incident_url(self.first_incident_id)
+        self.mock_get_request(m, incident_url, self.first_incident_data)
+
+        second_incident_url = self.build_incident_url(self.second_incident_id)
+        self.mock_get_request(m, second_incident_url, self.second_incident_data)
+
+        alert_url = self.build_alert_url(self.first_incident_id, self.first_alert_id)
+        self.mock_get_request(m, alert_url, self.first_alert_data)
+        self.mock_put_request(m, alert_url, self.first_alert_data)
+
+        incident = Incident.fetch(self.first_incident_id, api_key=self.api_key)
+        new_incident = Incident.fetch(self.second_incident_id, api_key=self.api_key)
+        alert = Alert.fetch(self.first_alert_id, incident, None, api_key=self.api_key)
+        alert.associate(new_incident, 'nizar@pagerduty.com')
+
+        last_request_json = m.last_request.json()
+        self.assertEqual('PUT', m.last_request.method)
+        self.assertEqual(self.first_alert_id, last_request_json['alert']['id'])
+        self.assertEqual(self.second_incident_id, last_request_json['alert']['incident']['id'])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduces support for alerts and incident merging.

Example:
```
action_email = 'nizar@pagerduty.com'
first_incident = Incident.fetch("ID1")
second_incident = Incident.fetch("ID2")
third_incident = Incident.fetch("ID3")

first_incident_alerts = first_incident.alerts()
first_incident_first_alert = first_incident_alerts[0]

# Resolve the first alert in the first incident
first_incident_first_alert.resolve(action_email)

# Associate first alert of first incident to the second incident
first_incident_first_alert.associate(second_incident, action_email)

# Merge the first and second incident into the third incident
source_incidents = [first_incident, second_incident]
third_incident.merge(source_incidents, action_email)
```