### PR TITLE
Fix for malformed query string on Python3

### DIFF
--- a/pypd/mixins.py
+++ b/pypd/mixins.py
@@ -92,7 +92,7 @@ class ClientMixin(object):
         if add_headers is not None:
             headers.update(**add_headers)
 
-        for k, v in query_params.items():
+        for k, v in query_params.copy().items():
             if isinstance(v, stringtype):
                 continue
             elif isinstance(v, Number):

--- a/test/unit/clientmixin.py
+++ b/test/unit/clientmixin.py
@@ -83,5 +83,15 @@ class ClientMixinTestCase(unittest.TestCase):
             headers=''
         )
 
+    def test_statuses_array(self, m):
+        method = 'GET'
+        body = {'status': 'OK'}
+        url = '%s?statuses[]=triggered&statuses[]=acknowledged' % self.url
+        m.register_uri(method, url, json=body)
+        result = self.requester.request(method, self.endpoint,
+                                        query_params={'statuses': ['triggered',
+                                                                   'acknowledged']})
+        self.assertEqual(body, result)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Python3 reevaluates the map at each iteration of the loop, use a copy of query_params to avoid reprocessing already seen items.  Fixes #21 