### PR TITLE
Use six for all the Python 2 and 3 compatibility needs

### DIFF
--- a/pypd/mixins.py
+++ b/pypd/mixins.py
@@ -9,6 +9,7 @@ from numbers import Number
 import sys
 
 import requests
+import six
 
 from .log import log
 from .errors import (BadRequest, UnknownError, InvalidResponse, InvalidHeaders)
@@ -17,12 +18,6 @@ from .errors import (BadRequest, UnknownError, InvalidResponse, InvalidHeaders)
 CONTENT_TYPE = 'application/vnd.pagerduty+json;version=2'
 AUTH_TEMPLATE = 'Token token={0}'
 BASIC_AUTH_TEMPLATE = 'Basic {0}'
-
-
-if sys.version_info[0] < 3:
-    stringtype = basestring
-else:
-    stringtype = str
 
 
 class ClientMixin(object):
@@ -94,7 +89,7 @@ class ClientMixin(object):
             headers.update(**add_headers)
 
         for k, v in query_params.copy().items():
-            if isinstance(v, stringtype):
+            if isinstance(v, six.string_types):
                 continue
             elif isinstance(v, Number):
                 continue

--- a/pypd/models/alert.py
+++ b/pypd/models/alert.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     import json
 
+import six
+
 from .entity import Entity
 from ..errors import InvalidArguments, MissingFromEmail
 
@@ -26,7 +28,7 @@ class Alert(Entity):
 
     def resolve(self, from_email):
         """Resolve an alert using a valid email address."""
-        if from_email is None or not isinstance(from_email, basestring):
+        if from_email is None or not isinstance(from_email, six.string_types):
             raise MissingFromEmail(from_email)
 
         parent_incident_id = self['incident']['id']
@@ -50,7 +52,7 @@ class Alert(Entity):
 
     def associate(self, from_email, new_parent_incident=None):
         """Associate an alert with an incident using a valid email address."""
-        if from_email is None or not isinstance(from_email, basestring):
+        if from_email is None or not isinstance(from_email, six.string_types):
             raise MissingFromEmail(from_email)
 
         if new_parent_incident is None:

--- a/pypd/models/entity.py
+++ b/pypd/models/entity.py
@@ -12,7 +12,9 @@ try:
 except ImportError:
     import json
 
-from ..mixins import ClientMixin, stringtype
+import six
+
+from ..mixins import ClientMixin
 from ..log import warn
 
 
@@ -401,7 +403,7 @@ class Entity(ClientMixin):
         exclude = kwargs.pop('exclude', None)
 
         # if exclude param was passed a a string, list-ify it
-        if isinstance(exclude, stringtype):
+        if isinstance(exclude, six.string_types):
             exclude = [exclude, ]
 
         query_params = cls.translate_query_params(**kwargs)

--- a/pypd/models/event.py
+++ b/pypd/models/event.py
@@ -7,8 +7,9 @@ Entities should be used as the base for all things that ought to be queryable
 via PagerDuty v2 API.
 """
 
+import six
+
 from .entity import Entity
-from ..mixins import stringtype
 
 
 class Event(Entity):
@@ -22,12 +23,12 @@ class Event(Entity):
     def validate(cls, event_info):
         """Validate that provided event information is valid."""
         assert 'service_key' in event_info
-        assert isinstance(event_info['service_key'], stringtype)
+        assert isinstance(event_info['service_key'], six.string_types)
         assert 'event_type' in event_info
         assert event_info['event_type'] in cls.EVENT_TYPES
         if event_info['event_type'] != cls.EVENT_TYPES[0]:
             assert 'incident_key' in event_info
-            assert isinstance(event_info['incident_key'], stringtype)
+            assert isinstance(event_info['incident_key'], six.string_types)
         else:
             assert 'description' in event_info
 
@@ -62,7 +63,7 @@ class EventV2(Event):
     def validate(cls, event_info):
         """Validate that provided event information is valid."""
         assert 'routing_key' in event_info
-        assert isinstance(event_info['routing_key'], stringtype)
+        assert isinstance(event_info['routing_key'], six.string_types)
         assert 'event_action' in event_info
         assert event_info['event_action'] in cls.EVENT_TYPES
         assert 'payload' in event_info

--- a/pypd/models/incident.py
+++ b/pypd/models/incident.py
@@ -5,6 +5,8 @@ try:
 except ImportError:
     import json
 
+import six
+
 from .entity import Entity
 from .log_entry import LogEntry
 from .note import Note
@@ -23,7 +25,7 @@ class Incident(Entity):
 
     def resolve(self, from_email, resolution=None):
         """Resolve an incident using a valid email address."""
-        if from_email is None or not isinstance(from_email, basestring):
+        if from_email is None or not isinstance(from_email, six.string_types):
             raise MissingFromEmail(from_email)
 
         endpoint = '/'.join((self.endpoint, self.id,))
@@ -48,7 +50,7 @@ class Incident(Entity):
         """Resolve an incident using a valid email address."""
         endpoint = '/'.join((self.endpoint, self.id,))
 
-        if from_email is None or not isinstance(from_email, basestring):
+        if from_email is None or not isinstance(from_email, six.string_types):
             raise MissingFromEmail(from_email)
 
         add_headers = {'from': from_email, }
@@ -101,7 +103,7 @@ class Incident(Entity):
 
     def create_note(self, from_email, content):
         """Create a note for this incident."""
-        if from_email is None or not isinstance(from_email, basestring):
+        if from_email is None or not isinstance(from_email, six.string_types):
             raise MissingFromEmail(from_email)
 
         endpoint = '/'.join((self.endpoint, self.id, 'notes'))
@@ -116,7 +118,7 @@ class Incident(Entity):
 
     def snooze(self, from_email, duration):
         """Snooze this incident for `duration` seconds."""
-        if from_email is None or not isinstance(from_email, basestring):
+        if from_email is None or not isinstance(from_email, six.string_types):
             raise MissingFromEmail(from_email)
 
         endpoint = '/'.join((self.endpoint, self.id, 'snooze'))
@@ -132,7 +134,7 @@ class Incident(Entity):
 
     def merge(self, from_email, source_incidents):
         """Merge other incidents into this incident."""
-        if from_email is None or not isinstance(from_email, basestring):
+        if from_email is None or not isinstance(from_email, six.string_types):
             raise MissingFromEmail(from_email)
 
         add_headers = {'from': from_email, }

--- a/pypd/models/team.py
+++ b/pypd/models/team.py
@@ -1,9 +1,10 @@
 # Copyright (c) PagerDuty.
 # See LICENSE for details.
+import six
+
 from .entity import Entity
 from .user import User
 from .escalation_policy import EscalationPolicy
-from ..mixins import stringtype
 
 
 class Team(Entity):
@@ -17,7 +18,7 @@ class Team(Entity):
         if isinstance(escalation_policy, Entity):
             escalation_policy = escalation_policy['id']
 
-        assert isinstance(escalation_policy, stringtype)
+        assert isinstance(escalation_policy, six.string_types)
 
         endpoint = '{0}/{1}/escalation_policies/{2}'.format(
             self.endpoint,
@@ -32,7 +33,7 @@ class Team(Entity):
         if isinstance(escalation_policy, Entity):
             escalation_policy = escalation_policy['id']
 
-        assert isinstance(escalation_policy, stringtype)
+        assert isinstance(escalation_policy, six.string_types)
 
         endpoint = '{0}/{1}/escalation_policies/{2}'.format(
             self.endpoint,
@@ -46,7 +47,7 @@ class Team(Entity):
         if isinstance(user, Entity):
             user = user['id']
 
-        assert isinstance(user, stringtype)
+        assert isinstance(user, six.string_types)
 
         endpoint = '{0}/{1}/escalation_policies/{2}'.format(
             self.endpoint,
@@ -60,7 +61,7 @@ class Team(Entity):
         if isinstance(user, User):
             user = user['id']
 
-        assert isinstance(user, stringtype)
+        assert isinstance(user, six.string_types)
 
         endpoint = '{0}/{1}/users/{2}'.format(
             self.endpoint,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ujson
 requests
+six

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ options = {
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    'install_requires': ['requests'],
+    'install_requires': ['requests', 'six'],
     'tests_require': [],
     'extras_require': {
         'ujson': 'ujson',


### PR DESCRIPTION
It's just easier and means there's a common way of addressing the differences.

This also has the bonus of fixing the tests when run with Python 3.