### PR TITLE
Fix hardcoded snooze duration

### DIFF
--- a/pypd/models/incident.py
+++ b/pypd/models/incident.py
@@ -127,7 +127,7 @@ class Incident(Entity):
             api_key=self.api_key,
             add_headers=add_headers,
             data_key='duration',
-            data=3600,
+            data=duration,
         )
 
     def merge(self, from_email, source_incidents):


### PR DESCRIPTION
Found this bug via Pylint which complained about `duration` being an unused variable. I tried to change the duration value in both `pypd/models/incident.py` and `test/unit/models/incident.py` but it didn't make any tests fail, so I guess it's not something that's currently tested.