### PR TITLE
find_one() should return None if no results are found

### DIFF
--- a/pypd/models/entity.py
+++ b/pypd/models/entity.py
@@ -431,9 +431,13 @@ class Entity(ClientMixin):
         if 'maximum' not in kwargs:
             kwargs['maximum'] = 1
 
-        # call find and extract the first iterated value from the result
-        iterable = iter(cls.find(*args, **kwargs))
-        return next(iterable)
+        try:
+            # call find and extract the first iterated value from the result
+            iterable = iter(cls.find(*args, **kwargs))
+            return next(iterable)
+        except StopIteration:
+            # no result was found
+            return None
 
     @classmethod
     def create(cls, data=None, api_key=None, endpoint=None, add_headers=None,


### PR DESCRIPTION
Before this `find_one()` would throw a `StopIteration` exception in case no
results were found with the query which seems a bit hostile. `find()` on the
other hand returns an empty array so it would make more sense if `find_one()`
returned `None` in case no results were found.