### PR TITLE
Add return to Integration creation and fix typo

### DIFF
--- a/pypd/models/integration.py
+++ b/pypd/models/integration.py
@@ -76,5 +76,5 @@ class Integration(Entity):
             endpoint = 'services/{0}/integrations'.format(sid)
 
         # otherwise endpoint should contain the service path too
-        getattr(Entity, 'create').__func__(cls, endpoint=endpoint, data=data,
-                                          *args, **kwargs)
+        return getattr(Entity, 'create').__func__(cls, endpoint=endpoint,
+                                                  data=data, *args, **kwargs)

--- a/pypd/models/service.py
+++ b/pypd/models/service.py
@@ -25,7 +25,7 @@ class Service(Entity):
 
     def create_integration(self, integration_info, **kwargs):
         """
-        Create an integration for this incident.
+        Create an integration for this service.
 
         See: https://v2.developer.pagerduty.com/v2/page/api-reference#!/
               Services/post_services_id_integrations


### PR DESCRIPTION
The `return` statement was missing for the `create()` method.

If I was an over-achiever I would also add tests to reflect this change, however, I just wanted thing to work.

Also, I believe that the word `incident` was used where `service` was appropriate.