### PR TITLE
correct path typo for Teams.remove_user()

### DIFF
--- a/pypd/models/team.py
+++ b/pypd/models/team.py
@@ -49,7 +49,7 @@ class Team(Entity):
 
         assert isinstance(user, six.string_types)
 
-        endpoint = '{0}/{1}/escalation_policies/{2}'.format(
+        endpoint = '{0}/{1}/users/{2}'.format(
             self.endpoint,
             self['id'],
             user,


### PR DESCRIPTION
correcting typo in `remove_user()`

Fixes #46 