### PR TITLE
Add Events API V2 as integration type

### DIFF
--- a/pypd/models/integration.py
+++ b/pypd/models/integration.py
@@ -13,6 +13,8 @@ class Integration(Entity):
         'aws_cloudwatch_inbound_integration_reference',
         'cloudkick_inbound_integration',
         'cloudkick_inbound_integration_reference',
+        'events_api_v2_inbound_integration',
+        'events_api_v2_inbound_integration_reference',
         'event_transformer_api_inbound_integration',
         'event_transformer_api_inbound_integration_reference',
         'generic_email_inbound_integration',


### PR DESCRIPTION
This adds the ability to create integrations of the Events API V2 type.

This can then be used as follows:
```
service = pypd.Service.find_one(name='My Service Name')
integration_data = {
    'type': 'events_api_v2_inbound_integration',
    'name': name
}
pypd.Integration.create(service, data=integration_data)
```