### PR TITLE
Add a .save() method, fix .put()

### DIFF
--- a/pypd/models/entity.py
+++ b/pypd/models/entity.py
@@ -6,6 +6,7 @@ Entity module provides a base class Entity for defining a PagerDuty entity.
 Entities should be used as the base for all things that ought to be queryable
 via PagerDuty v2 API.
 """
+import copy
 import json
 import re
 
@@ -556,12 +557,26 @@ class Entity(ClientMixin):
             raise AttributeError("'%s' has no attribute '%s'" %
                                  (type(self), attr,))
 
+    def __setitem__(self, attr, value):
+        """Attribute accessor method in dict-like fashion."""
+        if hasattr(self, 'validate'):
+            new_data = copy.deepcopy(self._data)
+            new_data[attr] = value
+            self.validate(new_data)
+            self._set(new_data)
+        else:
+            self._data[attr] = value
+
     def get(self, attr, default=None):
         """Attribute accessor method in dict-like fashion."""
         try:
             return self[attr]
         except:
             return default
+
+    def set(self, attr, value):
+        """Attribute setter method in dict-like fashion."""
+        self[attr] = value
 
     def __json__(self):
         """Return a valid JSON string dump of the entity data."""

--- a/pypd/models/entity.py
+++ b/pypd/models/entity.py
@@ -6,7 +6,6 @@ Entity module provides a base class Entity for defining a PagerDuty entity.
 Entities should be used as the base for all things that ought to be queryable
 via PagerDuty v2 API.
 """
-import copy
 import json
 import re
 
@@ -559,8 +558,10 @@ class Entity(ClientMixin):
 
     def __setitem__(self, attr, value):
         """Attribute accessor method in dict-like fashion."""
+        # Make a shallow copy of data and validate, if the entity
+        # has the corresponding method.
         if hasattr(self, 'validate'):
-            new_data = copy.deepcopy(self._data)
+            new_data = self._data.copy()
             new_data[attr] = value
             self.validate(new_data)
             self._set(new_data)

--- a/pypd/models/entity.py
+++ b/pypd/models/entity.py
@@ -440,8 +440,8 @@ class Entity(ClientMixin):
             return None
 
     @classmethod
-    def create(cls, data=None, api_key=None, endpoint=None, add_headers=None,
-               data_key=None, response_data_key=None, method='POST', **kwargs):
+    def post(cls, data=None, api_key=None, endpoint=None, add_headers=None,
+             data_key=None, response_data_key=None, method='POST', **kwargs):
         """
         Create an instance of the Entity model by calling to the API endpoint.
 
@@ -475,7 +475,7 @@ class Entity(ClientMixin):
         return inst
 
     # sugar-pills
-    post = create
+    create = post
 
     @classmethod
     def delete(cls, id, api_key=None, **kwargs):
@@ -487,11 +487,16 @@ class Entity(ClientMixin):
         return True
 
     @classmethod
-    def put(cls, id, api_key=None, **kwargs):
-        """Delete an entity from the server by ID."""
-        inst = cls(api_key=api_key)
-        endpoint = '/'.join((cls.get_endpoint(), id))
-        return inst.request('PUT', endpoint=endpoint, query_params=kwargs)
+    def put(cls, id=None, data=None, api_key=None, endpoint=None):
+        """
+        Use the .create method's smarts to update an existing record
+        """
+        if id and not endpoint:
+            endpoint = '/'.join((cls.get_endpoint(), id))
+        return cls.post(data=data,
+                        api_key=api_key,
+                        endpoint=endpoint,
+                        method="PUT")
 
     @classmethod
     def _parse(cls, data, key=None):
@@ -535,9 +540,13 @@ class Entity(ClientMixin):
         """
         return self._data
 
+    def save(self):
+        """Update the server record with this record's data."""
+        return self.put(id=self.id, data=self._data)
+
     def remove(self):
         """Delete this instance from server record."""
-        return self.__class__.delete(self.id)
+        return self.delete(self.id)
 
     def __getitem__(self, attr):
         """Attribute accessor method in dict-like fashion."""

--- a/test/unit/models/entity.py
+++ b/test/unit/models/entity.py
@@ -327,29 +327,28 @@ class EntityTestCase(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_save(self, m):
-        item_id = "ENT01"
+        item_id = 'ENT01'
 
         item_record = {
-            "id": item_id
+            'id': item_id
         }
 
-        parse_key = (self.cls.sanitize_ep(self.cls.get_endpoint(), plural=False))
+        parse_key = (self.cls.sanitize_ep(self.cls.get_endpoint(),
+                                          plural=False))
 
         data = {
             parse_key: item_record
         }
 
-        entity_url = "{url}/{id}".format(url=self.url, id=item_id)
-
-        def update_record(request, context):
-            return data
+        entity_url = '{url}/{id}'.format(url=self.url, id=item_id)
 
         m.register_uri('GET', entity_url, json=data)
-        m.register_uri('PUT', entity_url, json=update_record)
+        m.register_uri('PUT', entity_url, json=data)
 
-        entity = self.cls.fetch(id="ENT01")
+        entity = self.cls.fetch(id='ENT01')
         entity.save()
 
+        # Make sure PUT endpoint is called
         self.assertTrue(
             any((entity_url, 'PUT') == (request.url, request.method)
                 for request in m.request_history)

--- a/test/unit/models/entity.py
+++ b/test/unit/models/entity.py
@@ -50,6 +50,14 @@ class EntityTestCase(unittest.TestCase):
         class TestEntity(Entity):
             endpoint = self.endpoint
 
+            @staticmethod
+            def validate(new_data):
+                allowed_keys = {'id', 'other_thing'}
+
+                for key in new_data:
+                    if key not in allowed_keys:
+                        raise ValueError("Invalid new key: %s" % key)
+
         self.cls = TestEntity
 
     def test_sanitize_endpoint(self):
@@ -354,6 +362,14 @@ class EntityTestCase(unittest.TestCase):
                 for request in m.request_history)
         )
 
+    @requests_mock.Mocker()
+    def test_update(self, m):
+        entity = self.cls()
+        entity._set({'id': 'OLDID'})
+        entity['id'] = 'ENTTEST'
+        entity['other_thing'] = 'Other thing to set'
+        with self.assertRaises(ValueError):
+            entity['bad_key'] = 'hello'
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/models/entity.py
+++ b/test/unit/models/entity.py
@@ -325,6 +325,36 @@ class EntityTestCase(unittest.TestCase):
             )
             self.assertTrue(isinstance(entities[n], TestParseFunction))
 
+    @requests_mock.Mocker()
+    def test_save(self, m):
+        item_id = "ENT01"
+
+        item_record = {
+            "id": item_id
+        }
+
+        parse_key = (self.cls.sanitize_ep(self.cls.get_endpoint(), plural=False))
+
+        data = {
+            parse_key: item_record
+        }
+
+        entity_url = "{url}/{id}".format(url=self.url, id=item_id)
+
+        def update_record(request, context):
+            return data
+
+        m.register_uri('GET', entity_url, json=data)
+        m.register_uri('PUT', entity_url, json=update_record)
+
+        entity = self.cls.fetch(id="ENT01")
+        entity.save()
+
+        self.assertTrue(
+            any((entity_url, 'PUT') == (request.url, request.method)
+                for request in m.request_history)
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/models/entity.py
+++ b/test/unit/models/entity.py
@@ -362,8 +362,7 @@ class EntityTestCase(unittest.TestCase):
                 for request in m.request_history)
         )
 
-    @requests_mock.Mocker()
-    def test_update(self, m):
+    def test_update(self):
         entity = self.cls()
         entity._set({'id': 'OLDID'})
         entity['id'] = 'ENTTEST'


### PR DESCRIPTION
I noticed that the `.put` method on entities didn't work the way I'd expect (I'm editing a lot of records). It seems as though the implementation assumes `PUT` is a variation on `DELETE` and not on `POST`, which seems exactly backwards to me. I've updated put to use create, and I've added an inline `.save()` method that will use `PUT` to edit a record.

Test included.